### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Scripts/bootstrap.bundle.js
+++ b/Scripts/bootstrap.bundle.js
@@ -1102,7 +1102,7 @@
         return;
       }
 
-      var target = $__default['default'](selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$__default['default'](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ValhallaTech/TacoCatRadar/security/code-scanning/2](https://github.com/ValhallaTech/TacoCatRadar/security/code-scanning/2)

General fix: avoid passing untrusted strings to jQuery’s `$()` constructor. Resolve DOM nodes via native DOM APIs (or jQuery APIs that only parse selectors) and then pass elements to jQuery only after lookup.

Best fix here (without changing behavior): in `Carousel._dataApiClickHandler`, replace:

- `var target = $__default['default'](selector)[0];`

with:

- `var target = document.querySelector(selector);`

This keeps selector semantics, avoids HTML parsing behavior of `$()`, and preserves subsequent logic (`hasClass`, `.data()`, etc.) since those already wrap `target` as an element.

File/region to change: `Scripts/bootstrap.bundle.js`, around lines 1098–1107 in `_dataApiClickHandler`.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
