### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/Scripts/bootstrap.js
+++ b/Scripts/bootstrap.js
@@ -1103,7 +1103,7 @@
         return;
       }
 
-      var target = $__default['default'](selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$__default['default'](target).hasClass(CLASS_NAME_CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ValhallaTech/TacoCatRadar/security/code-scanning/1](https://github.com/ValhallaTech/TacoCatRadar/security/code-scanning/1)

To fix this without changing behavior, avoid passing untrusted string data into jQuery’s `$()` constructor.  
Here, `selector` is intended to be a CSS selector only, so resolve it via a DOM selector API (or jQuery’s selector-only API) and then wrap the resulting element, instead of giving jQuery the raw string.

Best targeted fix in `Scripts/bootstrap.js`:
- In `Carousel._dataApiClickHandler` (around line 1106), replace:
  - `var target = $__default['default'](selector)[0];`
- With:
  - `var target = document.querySelector(selector);`

This keeps functionality (getting the first matching target element), avoids HTML interpretation, and removes the DOM-text-to-HTML risk. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
